### PR TITLE
Added Output.map to PrintBox for unicode rendering

### DIFF
--- a/src/printBox.ml
+++ b/src/printBox.ml
@@ -59,87 +59,7 @@ module Output = struct
   let put_string out pos s = out.put_string pos s
   let put_sub_string out pos s s_i s_len = out.put_sub_string pos s s_i s_len
 
-  (** An internal buffer, suitable for writing efficiently, then
-      convertable into a list of lines *)
-  type buffer = {
-    mutable buf_lines : buf_line array;
-    mutable buf_len : int;
-  }
-  and buf_line = {
-    mutable bl_str : Bytes.t;
-    mutable bl_len : int;
-  }
-
-  let _make_line _ = {bl_str=Bytes.empty; bl_len=0}
-
-  let _ensure_lines buf i =
-    if i >= Array.length buf.buf_lines
-    then (
-      let lines' = Array.init (2 * i + 5) _make_line in
-      Array.blit buf.buf_lines 0 lines' 0 buf.buf_len;
-      buf.buf_lines <- lines';
-    )
-
-  let _ensure_line line i =
-    if i >= Bytes.length line.bl_str
-    then (
-      let str' = Bytes.make (2 * i + 5) ' ' in
-      Bytes.blit line.bl_str 0 str' 0 line.bl_len;
-      line.bl_str <- str';
-    )
-
-  let _buf_put_char buf pos c =
-    _ensure_lines buf pos.y;
-    _ensure_line buf.buf_lines.(pos.y) pos.x;
-    buf.buf_len <- max buf.buf_len (pos.y+1);
-    let line = buf.buf_lines.(pos.y) in
-    Bytes.set line.bl_str pos.x c;
-    line.bl_len <- max line.bl_len (pos.x+1)
-
-  let _buf_put_sub_string buf pos s s_i s_len =
-    _ensure_lines buf pos.y;
-    _ensure_line buf.buf_lines.(pos.y) (pos.x + s_len);
-    buf.buf_len <- max buf.buf_len (pos.y+1);
-    let line = buf.buf_lines.(pos.y) in
-    String.blit s s_i line.bl_str pos.x s_len;
-    line.bl_len <- max line.bl_len (pos.x+s_len)
-
-  let _buf_put_string buf pos s =
-    _buf_put_sub_string buf pos s 0 (String.length s)
-
-  (* create a new buffer *)
-  let make_buffer () =
-    let buf = {
-      buf_lines = Array.init 16 _make_line;
-      buf_len = 0;
-    } in
-    let buf_out = {
-      put_char = _buf_put_char buf;
-      put_sub_string = _buf_put_sub_string buf;
-      put_string = _buf_put_string buf;
-      flush = (fun () -> ());
-    } in
-    buf, buf_out
-
-  let buf_to_lines ?(indent=0) buf =
-    let buffer = Buffer.create (5 + buf.buf_len * 32) in
-    for i = 0 to buf.buf_len - 1 do
-      for _k = 1 to indent do Buffer.add_char buffer ' ' done;
-      let line = buf.buf_lines.(i) in
-      Buffer.add_substring buffer (Bytes.unsafe_to_string line.bl_str) 0 line.bl_len;
-      Buffer.add_char buffer '\n';
-    done;
-    Buffer.contents buffer
-
-  let buf_output ?(indent=0) oc buf =
-    for i = 0 to buf.buf_len - 1 do
-      for _k = 1 to indent do output_char oc ' '; done;
-      let line = buf.buf_lines.(i) in
-      output oc line.bl_str 0 line.bl_len;
-      output_char oc '\n';
-    done
-
-  (** Internal sort-of buffer suitable for unicode strings.
+  (** Internal multi-line buffer suitable for unicode strings.
       It is a map from start position to a printable entity (string or character)
       All printable sequences are supposed to *NOT* introduce new lines *)
   module M = Map.Make(struct type t = position let compare = _cmp end)
@@ -148,32 +68,32 @@ module Output = struct
     | Char of char
     | String of string
 
-  type map = {
+  type buffer = {
     mutable map : printable M.t
   }
 
   (* Note: we trust the user not to mess things up relating to
      strings overlapping because of bad positions *)
-  let _map_put_char map pos c =
-    map.map <- M.add pos (Char c) map.map
+  let _buf_put_char buf pos c =
+    buf.map <- M.add pos (Char c) buf.map
 
-  let _map_put_string map pos s =
-    map.map <- M.add pos (String s) map.map
+  let _buf_put_string buf pos s =
+    buf.map <- M.add pos (String s) buf.map
 
-  let _map_put_sub_string map pos s s_i s_len =
-    map.map <- M.add pos (String (String.sub s s_i s_len)) map.map
+  let _buf_put_sub_string buf pos s s_i s_len =
+    buf.map <- M.add pos (String (String.sub s s_i s_len)) buf.map
 
-  let make_map () =
-    let map  = { map = M.empty } in
-    let map_out = {
-      put_char = _map_put_char map;
-      put_string = _map_put_string map;
-      put_sub_string = _map_put_sub_string map;
+  let make_buffer () =
+    let buf  = { map = M.empty } in
+    let buf_out = {
+      put_char = _buf_put_char buf;
+      put_string = _buf_put_string buf;
+      put_sub_string = _buf_put_sub_string buf;
       flush = (fun () -> ());
     } in
-    map, map_out
+    buf, buf_out
 
-  let rec map_out_aux ?(indent=0) buf start_pos p curr_pos =
+  let rec buf_out_aux ?(indent=0) buf start_pos p curr_pos =
     assert (_cmp curr_pos start_pos <= 0);
     (* Go up to the expected location *)
     for i = curr_pos.y to start_pos.y - 1 do
@@ -198,18 +118,18 @@ module Output = struct
       let l = !_string_len (Bytes.of_string s) in
       _move_x start_pos l
 
-  let map_out ?(indent=0) buf map =
+  let buf_out ?(indent=0) buf b =
     for i = 1 to indent do Buffer.add_char buf ' ' done;
-    let _pos = M.fold (map_out_aux ~indent buf) map.map origin in ()
+    let _pos = M.fold (buf_out_aux ~indent buf) b.map origin in ()
 
-  let map_to_lines ?indent map =
+  let buf_to_lines ?indent b =
     let buf = Buffer.create 42 in
-    map_out ?indent buf map;
+    buf_out ?indent buf b;
     Buffer.contents buf
 
-  let map_output ?indent oc map =
+  let buf_output ?indent oc b =
     let buf = Buffer.create 42 in
-    map_out ?indent buf map;
+    buf_out ?indent buf b;
     Buffer.output_buffer oc buf
 
 end
@@ -541,9 +461,9 @@ let to_string b =
   Output.buf_to_lines buf
 
 let output ?indent oc b =
-  let map, out = Output.make_map () in
+  let buf, out = Output.make_buffer () in
   render out b;
-  Output.map_output ?indent oc map;
+  Output.buf_output ?indent oc buf;
   flush oc
 
 (** {2 Simple Structural Interface} *)

--- a/src/printBox.ml
+++ b/src/printBox.ml
@@ -540,13 +540,7 @@ let to_string b =
   render out b;
   Output.buf_to_lines buf
 
-let output ?(indent=0) oc b =
-  let buf, out = Output.make_buffer () in
-  render out b;
-  Output.buf_output ~indent oc buf;
-  flush oc
-
-let output_unicode ?indent oc b =
+let output ?indent oc b =
   let map, out = Output.make_map () in
   render out b;
   Output.map_output ?indent oc map;

--- a/src/printBox.ml
+++ b/src/printBox.ml
@@ -198,8 +198,9 @@ module Output = struct
       let l = !_string_len (Bytes.of_string s) in
       _move_x start_pos l
 
-  let map_out ?indent buf map =
-    let _pos = M.fold (map_out_aux ?indent buf) map.map origin in ()
+  let map_out ?(indent=0) buf map =
+    for i = 1 to indent do Buffer.add_char buf ' ' done;
+    let _pos = M.fold (map_out_aux ~indent buf) map.map origin in ()
 
   let map_to_lines ?indent map =
     let buf = Buffer.create 42 in

--- a/src/printBox.mli
+++ b/src/printBox.mli
@@ -91,7 +91,9 @@ module Output : sig
   type buffer
 
   val make_buffer : unit -> buffer * t
-  (** New buffer, and the corresponding output (buffers are mutable) *)
+  (** New buffer, and the corresponding output (buffers are mutable)
+      Calls to [put_char], [put_string], and [put_sub_string]
+      should *NOT* write characters on overlapping positions. *)
 
   val buf_to_lines : ?indent:int -> buffer -> string
   (** Print the content of the buffer into a string.
@@ -99,22 +101,6 @@ module Output : sig
 
   val buf_output : ?indent:int -> out_channel -> buffer -> unit
   (** Print the buffer on the given channel *)
-
-  (** {6 Unicode instance : a string map} *)
-
-  type map
-
-  val make_map : unit -> map * t
-  (** New map, and the corresponding output [t] (maps are mutable).
-      Calls to [t.put_char], [t.put_string], and [t.put_sub_string]
-      should *NOT* write characters on overlapping positions. *)
-
-  val map_to_lines : ?indent:int -> map -> string
-  (** Print the contents of the map into a string.
-      @param indent number of spaces to insert in front of the lines *)
-
-  val map_output : ?indent:int -> out_channel -> map -> unit
-  (** Print the map on the given channel *)
 
 end
 

--- a/src/printBox.mli
+++ b/src/printBox.mli
@@ -99,6 +99,23 @@ module Output : sig
 
   val buf_output : ?indent:int -> out_channel -> buffer -> unit
   (** Print the buffer on the given channel *)
+
+  (** {6 Unicode instance : a string map} *)
+
+  type map
+
+  val make_map : unit -> map * t
+  (** New map, and the corresponding output [t] (maps are mutable).
+      Calls to [t.put_char], [t.put_string], and [t.put_sub_string]
+      should *NOT* writer characters on overlapping positions. *)
+
+  val map_to_lines : ?indent:int -> map -> string
+  (** Print the contents of the map into a string.
+      @param indent number of spaces to insert in front of the lines *)
+
+  val map_output : ?indent:int -> out_channel -> map -> unit
+  (** Print the map on the given channel *)
+
 end
 
 (** {2 Box Combinators} *)
@@ -194,6 +211,8 @@ val render : Output.t -> Box.t -> unit
 val to_string : Box.t -> string
 
 val output : ?indent:int -> out_channel -> Box.t -> unit
+
+val output_unicode : ?indent:int -> out_channel -> Box.t -> unit
 
 (** {2 Simple Structural Interface} *)
 

--- a/src/printBox.mli
+++ b/src/printBox.mli
@@ -107,7 +107,7 @@ module Output : sig
   val make_map : unit -> map * t
   (** New map, and the corresponding output [t] (maps are mutable).
       Calls to [t.put_char], [t.put_string], and [t.put_sub_string]
-      should *NOT* writer characters on overlapping positions. *)
+      should *NOT* write characters on overlapping positions. *)
 
   val map_to_lines : ?indent:int -> map -> string
   (** Print the contents of the map into a string.

--- a/src/printBox.mli
+++ b/src/printBox.mli
@@ -212,8 +212,6 @@ val to_string : Box.t -> string
 
 val output : ?indent:int -> out_channel -> Box.t -> unit
 
-val output_unicode : ?indent:int -> out_channel -> Box.t -> unit
-
 (** {2 Simple Structural Interface} *)
 
 type 'a ktree = unit -> [`Nil | `Node of 'a * 'a ktree list]

--- a/src/printBox.mli
+++ b/src/printBox.mli
@@ -74,7 +74,17 @@ val origin : position
 
 val set_string_len : (Bytes.t -> int) -> unit
 (** Set which function is used to compute string length. Typically
-    to be used with a unicode-sensitive length function *)
+    to be used with a unicode-sensitive length function.
+    An example of such function for utf8 encoded strings is the following
+    (it uses the Uutf library):
+    {[
+      let string_leng s =
+        let d = Uutf.decoder (`String s) in
+        while (let c = Uutf.decode d in c <> `Await || c <> `End) do () done;
+        Uutf.decoder_count d
+    ]}
+    Note that this function assumes there is no newline character in the given string.
+    *)
 
 (** {2 Output} *)
 


### PR DESCRIPTION
This PR adds a new type and associated functions in `PrintBox.Output` which should be more adapted to handle rendering of Boxes containing unicode strings.

Since one cannot statically know the actual length of the unicode string that will be used to print a certainnumber of characters, we cannot use a single string to hold the contents of a line. Instead, the idea is to store the contents to print as a map from the starting position to the string to print, that way one can easily insert a string of arbitrary length wherever is needed.

There are two caveats with the current implementation. The first is that we trust that  the strings in `put_string` and `put_sub_string` do not contain a new line character (I'm still a bit fuzzy on how newline works in unicode, and if that property could be quickly checked). The other one is that if the contents to be printed overlap, then an error is raised when printing while it would be more natural it be raised when inserting the incorrectly positioned string/character.

As a side note, I tested the new implementation on the two examples given in the documentation of the module and they rendered fine as far as I could tell, however I didn't yet test it using unicode encoded strings (ironically).
